### PR TITLE
Enhance JSON form creation UI

### DIFF
--- a/portal/src/components/NewFormJSON.tsx
+++ b/portal/src/components/NewFormJSON.tsx
@@ -9,6 +9,11 @@ export const NewFormJSON = () => {
     const [jsonText, setJsonText] = useState("");
     const [file, setFile] = useState<File | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [title, setTitle] = useState("");
+    const [name, setName] = useState("");
+    const [path, setPath] = useState("");
+    const [display, setDisplay] = useState("form");
+    const [tags, setTags] = useState("");
 
     const readFile = async (f: File) => {
         const text = await f.text();
@@ -36,6 +41,16 @@ export const NewFormJSON = () => {
             setError("Invalid JSON");
             return;
         }
+
+        parsed.title = title || parsed.title;
+        parsed.name = name || parsed.name;
+        parsed.path = path || parsed.path;
+        parsed.display = display || parsed.display || "form";
+        parsed.type = parsed.type || "form";
+        parsed.tags = tags
+            ? tags.split(",").map((t) => t.trim()).filter(Boolean)
+            : parsed.tags || [];
+
         try {
             const created = await Formio.request("/form", "POST", parsed);
             setLocation(`/form/${created._id}/edit`);
@@ -57,6 +72,57 @@ export const NewFormJSON = () => {
                 </div>
             </div>
             <div className="panel new-item" style={{ padding: "15px" }}>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Form Title"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Form Name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Path"
+                        value={path}
+                        onChange={(e) => setPath(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <select
+                        value={display}
+                        onChange={(e) => setDisplay(e.target.value)}
+                        style={{ width: "100%" }}
+                    >
+                        <option value="form">Form</option>
+                        <option value="wizard">Wizard</option>
+                    </select>
+                </div>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Tags (comma-separated)"
+                        value={tags}
+                        onChange={(e) => setTags(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <small>
+                        Paste a Form.io form JSON including a components array.
+                    </small>
+                </div>
                 <div className="mb-2">
                     <textarea
                         placeholder="Paste form JSON here..."

--- a/portal/src/components/NewFormJSON.tsx
+++ b/portal/src/components/NewFormJSON.tsx
@@ -71,76 +71,83 @@ export const NewFormJSON = () => {
                     </button>
                 </div>
             </div>
-            <div className="panel new-item" style={{ padding: "15px" }}>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Form Title"
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
+            <div className="panel new-item">
+                <div className="edit-form-header">
+                    <div className="edit-form-header-left">
+                        <div className="formio-component form-group lateral">
+                            <label htmlFor="title">Form Title</label>
+                            <input
+                                id="title"
+                                type="text"
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                            />
+                        </div>
+                        <div className="formio-component form-group lateral">
+                            <label htmlFor="name">Form Name</label>
+                            <input
+                                id="name"
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                            />
+                        </div>
+                        <div className="formio-component form-group lateral">
+                            <label htmlFor="path">Path</label>
+                            <input
+                                id="path"
+                                type="text"
+                                value={path}
+                                onChange={(e) => setPath(e.target.value)}
+                            />
+                        </div>
+                        <div className="formio-component form-group lateral">
+                            <label htmlFor="display">Display As</label>
+                            <select
+                                id="display"
+                                value={display}
+                                onChange={(e) => setDisplay(e.target.value)}
+                            >
+                                <option value="form">Form</option>
+                                <option value="wizard">Wizard</option>
+                            </select>
+                        </div>
+                        <div className="formio-component form-group lateral">
+                            <label htmlFor="tags">Tags</label>
+                            <input
+                                id="tags"
+                                type="text"
+                                value={tags}
+                                onChange={(e) => setTags(e.target.value)}
+                            />
+                        </div>
+                    </div>
                 </div>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Form Name"
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Path"
-                        value={path}
-                        onChange={(e) => setPath(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <select
-                        value={display}
-                        onChange={(e) => setDisplay(e.target.value)}
-                        style={{ width: "100%" }}
-                    >
-                        <option value="form">Form</option>
-                        <option value="wizard">Wizard</option>
-                    </select>
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Tags (comma-separated)"
-                        value={tags}
-                        onChange={(e) => setTags(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <small>
-                        Paste a Form.io form JSON including a components array.
-                    </small>
-                </div>
-                <div className="mb-2">
-                    <textarea
-                        placeholder="Paste form JSON here..."
-                        value={jsonText}
-                        onChange={(e) => setJsonText(e.target.value)}
-                        style={{ width: "100%", height: "200px" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="file"
-                        accept="application/json"
-                        onChange={handleFile}
-                    />
-                </div>
-                {error && <div className="error" role="alert">{error}</div>}
-                <div className="save-form-bar button-wrap" style={{ justifyContent: "end" }}>
-                    <button className="button save-form" onClick={handleSubmit}>Create Form</button>
+                <div style={{ padding: "15px" }}>
+                    <div className="mb-2">
+                        <small>
+                            Paste a Form.io form JSON including a components array.
+                        </small>
+                    </div>
+                    <div className="mb-2">
+                        <textarea
+                            placeholder="Paste form JSON here..."
+                            value={jsonText}
+                            onChange={(e) => setJsonText(e.target.value)}
+                            style={{ width: "100%", height: "200px" }}
+                        />
+                    </div>
+                    <div className="mb-2">
+                        <input
+                            type="file"
+                            accept="application/json"
+                            onChange={handleFile}
+                        />
+                    </div>
+                    {error && <div className="error" role="alert">{error}</div>}
+                    <div className="save-form-bar button-wrap" style={{ justifyContent: "end" }}>
+                        <button className="button save-form" onClick={handleSubmit}>Create Form</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/portal/test/newformjson.test.tsx
+++ b/portal/test/newformjson.test.tsx
@@ -36,7 +36,7 @@ test('Clicking on + New Form with JSON button navigates to the new form json pag
   const newFormButton = await screen.findByText('+ New Form with JSON');
   await userEvent.click(newFormButton);
   expect(await screen.findByText('Create Form via JSON'));
-  expect(await screen.findByPlaceholderText('Form Title'));
+  expect(await screen.findByText('Form Title'));
   expect(window.location.href).to.include('/newformjson');
 });
 
@@ -60,9 +60,9 @@ test('Creating a form with JSON should take you to edit form', async () => {
   );
 
   await userEvent.click(await screen.findByText('+ New Form with JSON'));
-  await userEvent.type(screen.getByPlaceholderText('Form Title'), 'My Form');
-  await userEvent.type(screen.getByPlaceholderText('Form Name'), 'myForm');
-  await userEvent.type(screen.getByPlaceholderText('Path'), 'myForm');
+  await userEvent.type(screen.getByLabelText('Form Title'), 'My Form');
+  await userEvent.type(screen.getByLabelText('Form Name'), 'myForm');
+  await userEvent.type(screen.getByLabelText('Path'), 'myForm');
   await userEvent.type(screen.getByPlaceholderText('Paste form JSON here...'), '{"components": []}');
   await userEvent.click(screen.getByText('Create Form'));
   const editFormTab = await screen.findByText('Edit Form');

--- a/portal/test/newformjson.test.tsx
+++ b/portal/test/newformjson.test.tsx
@@ -1,0 +1,82 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { Formio } from '@formio/js';
+import { FormioProvider } from '@formio/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { InfoPanelProvider } from '../src/hooks/useInfoPanelContext';
+import App from '../src/components/App';
+
+const server = setupServer(
+  http.get('http://localhost:3002/current', () => {
+    return HttpResponse.json({});
+  }),
+  http.get('http://localhost:3002/form', () => {
+    return HttpResponse.json([]);
+  })
+);
+
+beforeAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  localStorage.setItem('formioToken', '12345');
+  render(
+    <FormioProvider baseUrl="http://localhost:3002">
+      <InfoPanelProvider>
+        <App />
+      </InfoPanelProvider>
+    </FormioProvider>
+  );
+});
+
+test('Clicking on + New Form with JSON button navigates to the new form json page', async () => {
+  const newFormButton = await screen.findByText('+ New Form with JSON');
+  await userEvent.click(newFormButton);
+  expect(await screen.findByText('Create Form via JSON'));
+  expect(await screen.findByPlaceholderText('Form Title'));
+  expect(window.location.href).to.include('/newformjson');
+});
+
+test('Creating a form with JSON should take you to edit form', async () => {
+  server.use(
+    http.post('http://localhost:3002/form', async ({ request }) => {
+      const body = await request.json();
+      return HttpResponse.json({ _id: '679999999999999999999999', ...body });
+    }),
+    http.get('/form/679999999999999999999999', () => {
+      return HttpResponse.json({
+        _id: '679999999999999999999999',
+        title: 'My Form',
+        name: 'myForm',
+        path: 'myForm',
+        type: 'form',
+        display: 'form',
+        components: []
+      });
+    })
+  );
+
+  await userEvent.click(await screen.findByText('+ New Form with JSON'));
+  await userEvent.type(screen.getByPlaceholderText('Form Title'), 'My Form');
+  await userEvent.type(screen.getByPlaceholderText('Form Name'), 'myForm');
+  await userEvent.type(screen.getByPlaceholderText('Path'), 'myForm');
+  await userEvent.type(screen.getByPlaceholderText('Paste form JSON here...'), '{"components": []}');
+  await userEvent.click(screen.getByText('Create Form'));
+  const editFormTab = await screen.findByText('Edit Form');
+  expect(Array.from(editFormTab.classList)).contains('active');
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  Formio.clearCache();
+  Formio.tokens = {};
+  localStorage.clear();
+  window.location.href = '';
+});
+
+afterAll(() => {
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add form metadata fields to `NewFormJSON`
- combine pasted JSON with metadata before submit
- add vitest coverage for new JSON flow

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68631e9f84d48320910b23a33df75d91