### PR TITLE
Add metadata inputs for JSON form creation

### DIFF
--- a/portal/src/components/NewFormJSON.tsx
+++ b/portal/src/components/NewFormJSON.tsx
@@ -84,74 +84,103 @@ export const NewFormJSON = () => {
                     </button>
                 </div>
             </div>
-            <div className="panel new-item" style={{ padding: "15px" }}>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Form Title"
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Form Name (unique)"
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Path (e.g., myForm)"
-                        value={path}
-                        onChange={(e) => setPath(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <select
-                        value={display}
-                        onChange={(e) => setDisplay(e.target.value)}
-                    >
-                        <option value="form">Form</option>
-                        <option value="wizard">Wizard</option>
-                    </select>
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="text"
-                        placeholder="Tags (comma-separated)"
-                        value={tags}
-                        onChange={(e) => setTags(e.target.value)}
-                        style={{ width: "100%" }}
-                    />
-                </div>
-                <div className="mb-2">
-                    <textarea
-                        placeholder="Paste form JSON here..."
-                        value={jsonText}
-                        onChange={(e) => setJsonText(e.target.value)}
-                        style={{ width: "100%", height: "200px" }}
-                    />
-                    <small>
-                        Paste a Form.io JSON including a components array. The
-                        metadata above will be applied on save.
-                    </small>
-                </div>
-                <div className="mb-2">
-                    <input
-                        type="file"
-                        accept="application/json"
-                        onChange={handleFile}
-                    />
-                </div>
-                {error && <div className="error" role="alert">{error}</div>}
-                <div className="save-form-bar button-wrap" style={{ justifyContent: "end" }}>
-                    <button className="button save-form" onClick={handleSubmit}>Create Form</button>
+<div className="panel new-item">
+                <div className="edit-form-header">
+                    <div className="edit-form-header-left">
+                        <div className="formio-form-wrapper limit500">
+                            <div className="formio-component form-group lateral mb-2">
+                                <label htmlFor="title">Form Title</label>
+                                <div ref="element" style={{ width: "100%" }}>
+                                    <input
+                                        id="title"
+                                        name="data[title]"
+                                        type="text"
+                                        placeholder="Form Title"
+                                        value={title}
+                                        onChange={(e) => setTitle(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                            <div className="formio-component form-group lateral mb-2">
+                                <label htmlFor="name">Form Name</label>
+                                <div ref="element" style={{ width: "100%" }}>
+                                    <input
+                                        id="name"
+                                        name="data[name]"
+                                        type="text"
+                                        placeholder="Form Name"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                            <div className="formio-component form-group lateral mb-2">
+                                <label htmlFor="path">Path</label>
+                                <div ref="element" style={{ width: "100%" }}>
+                                    <input
+                                        id="path"
+                                        name="data[path]"
+                                        type="text"
+                                        placeholder="Path"
+                                        value={path}
+                                        onChange={(e) => setPath(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                            <div className="formio-component form-group lateral mb-2">
+                                <label htmlFor="display">Display As</label>
+                                <div ref="element" style={{ width: "100%" }}>
+                                    <select
+                                        id="display"
+                                        name="data[display]"
+                                        value={display}
+                                        onChange={(e) => setDisplay(e.target.value)}
+                                    >
+                                        <option value="form">Form</option>
+                                        <option value="wizard">Wizard</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div className="formio-component form-group lateral mb-2">
+                                <label htmlFor="tags">Tags</label>
+                                <div ref="element" style={{ width: "100%" }}>
+                                    <input
+                                        id="tags"
+                                        name="data[tags]"
+                                        type="text"
+                                        placeholder="comma,separated"
+                                        value={tags}
+                                        onChange={(e) => setTags(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="edit-form-header-right">
+                        <div className="mb-2">
+                            <textarea
+                                placeholder="Paste form JSON here..."
+                                value={jsonText}
+                                onChange={(e) => setJsonText(e.target.value)}
+                                style={{ width: "100%", height: "200px" }}
+                            />
+                            <small>
+                                Paste a Form.io JSON including a components array. The
+                                metadata above will be applied on save.
+                            </small>
+                        </div>
+                        <div className="mb-2">
+                            <input
+                                type="file"
+                                accept="application/json"
+                                onChange={handleFile}
+                            />
+                        </div>
+                        {error && <div className="error" role="alert">{error}</div>}
+                        <div className="save-form-bar button-wrap" style={{ justifyContent: "end" }}>
+                            <button className="button save-form" onClick={handleSubmit}>Create Form</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/portal/src/components/NewFormJSON.tsx
+++ b/portal/src/components/NewFormJSON.tsx
@@ -3,9 +3,21 @@ import { useState, ChangeEvent } from "react";
 import { useHashLocation } from "wouter/use-hash-location";
 import { useBodyClassName } from "../hooks/useBodyClassName";
 
+const slugify = (str: string) =>
+    str
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9-]/g, "");
+
 export const NewFormJSON = () => {
     useBodyClassName("item-open");
     const setLocation = useHashLocation()[1];
+    const [title, setTitle] = useState("");
+    const [name, setName] = useState("");
+    const [path, setPath] = useState("");
+    const [display, setDisplay] = useState("form");
+    const [tags, setTags] = useState("");
     const [jsonText, setJsonText] = useState("");
     const [file, setFile] = useState<File | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -29,13 +41,29 @@ export const NewFormJSON = () => {
             setError("JSON input required");
             return;
         }
-        let parsed;
+        let parsed: any;
         try {
             parsed = JSON.parse(input);
         } catch (e) {
             setError("Invalid JSON");
             return;
         }
+
+        parsed = { components: [], ...parsed };
+        parsed.title = title || parsed.title;
+        parsed.display = display || parsed.display || "form";
+        parsed.tags =
+            (tags
+                ? tags
+                      .split(",")
+                      .map((t) => t.trim())
+                      .filter(Boolean)
+                : parsed.tags) || [];
+
+        const genName = slugify(title);
+        parsed.name = name || parsed.name || genName;
+        parsed.path = path || parsed.path || parsed.name || genName;
+
         try {
             const created = await Formio.request("/form", "POST", parsed);
             setLocation(`/form/${created._id}/edit`);
@@ -58,12 +86,61 @@ export const NewFormJSON = () => {
             </div>
             <div className="panel new-item" style={{ padding: "15px" }}>
                 <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Form Title"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Form Name (unique)"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Path (e.g., myForm)"
+                        value={path}
+                        onChange={(e) => setPath(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
+                    <select
+                        value={display}
+                        onChange={(e) => setDisplay(e.target.value)}
+                    >
+                        <option value="form">Form</option>
+                        <option value="wizard">Wizard</option>
+                    </select>
+                </div>
+                <div className="mb-2">
+                    <input
+                        type="text"
+                        placeholder="Tags (comma-separated)"
+                        value={tags}
+                        onChange={(e) => setTags(e.target.value)}
+                        style={{ width: "100%" }}
+                    />
+                </div>
+                <div className="mb-2">
                     <textarea
                         placeholder="Paste form JSON here..."
                         value={jsonText}
                         onChange={(e) => setJsonText(e.target.value)}
                         style={{ width: "100%", height: "200px" }}
                     />
+                    <small>
+                        Paste a Form.io JSON including a components array. The
+                        metadata above will be applied on save.
+                    </small>
                 </div>
                 <div className="mb-2">
                     <input

--- a/portal/test/newformjson.test.tsx
+++ b/portal/test/newformjson.test.tsx
@@ -36,8 +36,8 @@ test('Clicking on + New Form with JSON shows metadata fields', async () => {
   const newJsonButton = await screen.findByText('+ New Form with JSON');
   await userEvent.click(newJsonButton);
   expect(await screen.findByText('Create Form via JSON'));
-  expect(await screen.findByPlaceholderText('Form Title'));
-  expect(await screen.findByPlaceholderText('Form Name (unique)'));
+  expect(await screen.findByText('Form Title'));
+  expect(await screen.findByText('Form Name'));
 });
 
 test('Creating a form with JSON navigates to edit form', async () => {
@@ -82,9 +82,9 @@ test('Creating a form with JSON navigates to edit form', async () => {
     })
   );
   await userEvent.click(await screen.findByText('+ New Form with JSON'));
-  await userEvent.type(await screen.findByPlaceholderText('Form Title'), 'test');
-  await userEvent.type(await screen.findByPlaceholderText('Form Name (unique)'), 'test');
-  await userEvent.type(await screen.findByPlaceholderText('Path (e.g., myForm)'), 'test');
+  await userEvent.type(document.querySelector('[name="data[title]"]')!, 'test');
+  await userEvent.type(document.querySelector('[name="data[name]"]')!, 'test');
+  await userEvent.type(document.querySelector('[name="data[path]"]')!, 'test');
   await userEvent.type(await screen.findByPlaceholderText('Paste form JSON here...'), '{"components":[]}');
   fireEvent.click(await screen.findByText('Create Form'));
   const editFormTab = await screen.findByText('Edit Form');

--- a/portal/test/newformjson.test.tsx
+++ b/portal/test/newformjson.test.tsx
@@ -1,0 +1,119 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { Formio } from '@formio/js';
+import { FormioProvider } from '@formio/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { InfoPanelProvider } from '../src/hooks/useInfoPanelContext';
+import App from '../src/components/App';
+
+const server = setupServer(
+  http.get('http://localhost:3002/current', () => {
+    return HttpResponse.json({});
+  }),
+  http.get('http://localhost:3002/form', () => {
+    return HttpResponse.json([]);
+  })
+);
+
+beforeAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  localStorage.setItem('formioToken', '12345');
+  render(
+    <FormioProvider baseUrl="http://localhost:3002">
+      <InfoPanelProvider>
+        <App />
+      </InfoPanelProvider>
+    </FormioProvider>
+  );
+});
+
+test('Clicking on + New Form with JSON shows metadata fields', async () => {
+  const newJsonButton = await screen.findByText('+ New Form with JSON');
+  await userEvent.click(newJsonButton);
+  expect(await screen.findByText('Create Form via JSON'));
+  expect(await screen.findByPlaceholderText('Form Title'));
+  expect(await screen.findByPlaceholderText('Form Name (unique)'));
+});
+
+test('Creating a form with JSON navigates to edit form', async () => {
+  server.use(
+    http.get('/form/679bc82961e9293dee60f88a', () => {
+      return HttpResponse.json({
+        '_id': '679bc82961e9293dee60f88a',
+        'title': 'test',
+        'name': 'test',
+        'path': 'test',
+        'type': 'form',
+        'display': 'form',
+        'tags': [''],
+        'owner': '679bc6e961e9293dee60f7fd',
+        'components': [],
+        'pdfComponents': [],
+        'access': [{ 'type': 'read_all', 'roles': ['679bc6de61e9293dee60f7aa'] }],
+        'submissionAccess': [],
+        'created': '2025-01-30T18:42:49.240Z',
+        'modified': '2025-01-30T18:42:49.243Z',
+        'machineName': 'test'
+      });
+    }),
+    http.post('http://localhost:3002/form', () => {
+      return HttpResponse.json({
+        '_id': '679bc82961e9293dee60f88a',
+        'title': 'test',
+        'name': 'test',
+        'path': 'test',
+        'type': 'form',
+        'display': 'form',
+        'tags': [''],
+        'owner': '679bc6e961e9293dee60f7fd',
+        'components': [],
+        'pdfComponents': [],
+        'access': [{ 'type': 'read_all', 'roles': ['679bc6de61e9293dee60f7aa'] }],
+        'submissionAccess': [],
+        'created': '2025-01-30T18:42:49.240Z',
+        'modified': '2025-01-30T18:42:49.243Z',
+        'machineName': 'test'
+      });
+    })
+  );
+  await userEvent.click(await screen.findByText('+ New Form with JSON'));
+  await userEvent.type(await screen.findByPlaceholderText('Form Title'), 'test');
+  await userEvent.type(await screen.findByPlaceholderText('Form Name (unique)'), 'test');
+  await userEvent.type(await screen.findByPlaceholderText('Path (e.g., myForm)'), 'test');
+  await userEvent.type(await screen.findByPlaceholderText('Paste form JSON here...'), '{"components":[]}');
+  fireEvent.click(await screen.findByText('Create Form'));
+  const editFormTab = await screen.findByText('Edit Form');
+  expect(Array.from(editFormTab.classList)).contains('active');
+});
+
+test('Submitting invalid JSON shows server error', async () => {
+  server.use(
+    http.post('http://localhost:3002/form', () => {
+      return HttpResponse.json({
+        'status': 400,
+        'message': 'form validation failed: path: Path `path` is required., name: Path `name` is required., title: Path `title` is required.'
+      }, { status: 400 });
+    })
+  );
+  await userEvent.click(await screen.findByText('+ New Form with JSON'));
+  await userEvent.type(await screen.findByPlaceholderText('Paste form JSON here...'), '{"components":[]}');
+  await userEvent.click(await screen.findByText('Create Form'));
+  expect(await screen.findByRole('alert'));
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  Formio.clearCache();
+  Formio.tokens = {};
+  localStorage.clear();
+  window.location.href = '';
+});
+
+afterAll(() => {
+  server.close();
+});


### PR DESCRIPTION
## Summary
- expand NewFormJSON to collect metadata fields
- auto-slug form names when they are not provided
- add helper text and field controls
- cover JSON form creation via new vitest tests

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*
- `cd portal && yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68631ea374948320b4218ce06175cd84